### PR TITLE
Fd 14022 redis objects migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ spec/redis.pid
 dump.rdb
 Gemfile.lock
 redis-objects-*.gem
+.byebug_history

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,9 @@
 source 'https://rubygems.org'
 
+group :development, :test do
+  gem 'byebug'
+  gem 'pry'
+end
+
 # Specify your gem's dependencies in redis-objects.gemspec
 gemspec

--- a/lib/redis/lock.rb
+++ b/lib/redis/lock.rb
@@ -38,7 +38,7 @@ class Redis
       try_until_timeout do
         expiration = generate_expiration
         # Use the expiration as the value of the lock.
-        break if !redis.get(key) && Redis.next.setnx(key, expiration)
+        break if redis.setnx(key, expiration) && Redis.next.setnx(key, expiration)
 
         # Lock is being held.  Now check to see if it's expired (if we're using
         # lock expiration).

--- a/lib/redis/objects.rb
+++ b/lib/redis/objects.rb
@@ -11,16 +11,6 @@ class Redis
   autoload :SortedSet, 'redis/sorted_set'
   autoload :Value,     'redis/value'
   autoload :HashKey,   'redis/hash_key'
-
-  # Monkey patching Redis to hold the migrating to DB called next
-  def self.next
-    raise "next Redis server connection needs to be explicitly set" unless @next
-    @next # ||= Redis.new
-  end
-
-  def self.next=(redis)
-    @next = redis
-  end
   #
   # Redis::Objects enables high-performance atomic operations in your app
   # by leveraging the atomic features of the Redis server.  To use Redis::Objects,

--- a/lib/redis/objects.rb
+++ b/lib/redis/objects.rb
@@ -12,6 +12,15 @@ class Redis
   autoload :Value,     'redis/value'
   autoload :HashKey,   'redis/hash_key'
 
+  # Monkey patching Redis to hold the migrating to DB called next
+  def self.next
+    raise "next Redis server connection needs to be explicitly set" unless @next
+    @next # ||= Redis.new
+  end
+
+  def self.next=(redis)
+    @next = redis
+  end
   #
   # Redis::Objects enables high-performance atomic operations in your app
   # by leveraging the atomic features of the Redis server.  To use Redis::Objects,
@@ -66,6 +75,16 @@ class Redis
       def redis
         @redis || $redis || Redis.current ||
           raise(NotConnected, "Redis::Objects.redis not set to a Redis.new connection")
+      end
+
+      # These are dependent on a monkey patch of Redis to include next. See above...
+      def redis_next=(conn)
+        raise "Explicit migrator Redis Connection required." unless conn
+        @redis_next = conn
+      end
+      def redis_next
+        @redis_next || Redis.next ||
+          raise(NotConnected, "Redis::Objects.redis_next not set to a Redis.new connection")
       end
 
       def included(klass)

--- a/spec/redis_objects_instance_spec.rb
+++ b/spec/redis_objects_instance_spec.rb
@@ -573,7 +573,7 @@ describe Redis::Lock do
     expiry = 15
     lock = Redis::Lock.new(:test_lock, :expiration => expiry)
     lock.lock do
-      expiration = REDIS_HANDLE.get("test_lock").to_f
+      expiration = Redis.next.get("test_lock").to_f
 
       # The expiration stored in redis should be 15 seconds from when we started
       # or a little more
@@ -581,17 +581,17 @@ describe Redis::Lock do
     end
 
     # key should have been cleaned up
-    REDIS_HANDLE.get("test_lock").should.be.nil
+    Redis.next.get("test_lock").should.be.nil
   end
 
   it "should set value to 1 when no expiration is set" do
     lock = Redis::Lock.new(:test_lock)
     lock.lock do
-      REDIS_HANDLE.get('test_lock').should == '1'
+      Redis.next.get('test_lock').should == '1'
     end
 
     # key should have been cleaned up
-    REDIS_HANDLE.get("test_lock").should.be.nil
+    Redis.next.get("test_lock").should.be.nil
   end
 
   it "should let lock be gettable when lock is expired" do
@@ -644,7 +644,7 @@ describe Redis::Lock do
     end
 
     # lock value should still be set since the lock was held for more than the expiry
-    REDIS_HANDLE.get("test_lock").should.not.be.nil
+    Redis.next.get("test_lock").should.not.be.nil
   end
 
   it "should respond to #to_json" do

--- a/spec/redis_objects_model_spec.rb
+++ b/spec/redis_objects_model_spec.rb
@@ -837,10 +837,10 @@ describe Redis::Objects do
       @team = Team.new
     end
 
-    it "should write new locks to new DB" do
+    it "should write new locks to both DBs" do
       @team.reorder_lock.lock do
         Redis.next.get(@team.reorder_lock.key).should == "1"
-        Redis.current.get(@team.reorder_lock.key).should == nil
+        Redis.current.get(@team.reorder_lock.key).should == "1"
       end
     end
 

--- a/spec/redis_objects_model_spec.rb
+++ b/spec/redis_objects_model_spec.rb
@@ -822,6 +822,26 @@ describe Redis::Objects do
     error.should.be.kind_of(Redis::Lock::LockTimeout)
   end
 
+  describe "migrating Locks to new Redis server" do
+    it "should write the lock key to the new DB" do
+      Redis.next.set("dennis", "great")
+      puts "Redis.current" 
+      puts Redis.current.info
+      puts "&&&&&&&&&&&&&&&&&&&&"
+
+      puts "Redis.next"
+      puts Redis.next.info
+
+      false.should.equal true
+    end
+    it "should not write to the old DB" do
+      false.should.equal true
+    end
+    it "should check for the lock in both DBs" do
+      false.should.equal true
+    end
+  end
+
   it "should pick up objects from superclass automatically" do
     @vanilla_roster.available_slots.should.be.kind_of(Redis::Counter)
     @vanilla_roster.pitchers.should.be.kind_of(Redis::Counter)

--- a/spec/redis_objects_model_spec.rb
+++ b/spec/redis_objects_model_spec.rb
@@ -454,7 +454,8 @@ describe Redis::Objects do
     error = nil
     begin
       Roster.obtain_lock(:resort, 2) do
-        Roster.redis.get("roster:2:resort_lock").should.not.be.nil
+        Redis.next.get("roster:2:resort_lock").should.not.be.nil
+        # Roster.redis.get("roster:2:resort_lock").should.not.be.nil
       end
     rescue => error
     end
@@ -823,22 +824,51 @@ describe Redis::Objects do
   end
 
   describe "migrating Locks to new Redis server" do
-    it "should write the lock key to the new DB" do
-      Redis.next.set("dennis", "great")
-      puts "Redis.current" 
-      puts Redis.current.info
-      puts "&&&&&&&&&&&&&&&&&&&&"
+    before do
 
-      puts "Redis.next"
-      puts Redis.next.info
+      class Team # < ActiveRecord::Base
+        def id # an ID method is required
+          1
+        end
+        include Redis::Objects
+        lock :reorder, :timeout => 2 # declare a lock
+      end
 
-      false.should.equal true
+      @team = Team.new
     end
-    it "should not write to the old DB" do
-      false.should.equal true
+
+    it "should write new locks to new DB" do
+      @team.reorder_lock.lock do
+        Redis.next.get(@team.reorder_lock.key).should == "1"
+        Redis.current.get(@team.reorder_lock.key).should == nil
+      end
     end
-    it "should check for the lock in both DBs" do
-      false.should.equal true
+
+    it "should remove locks from both DBs" do
+      @team.reorder_lock.lock { sleep 0.1 }
+      Redis.current.get(@team.reorder_lock.key).should == nil
+      Redis.next.get(@team.reorder_lock.key).should == nil
+    end
+
+    describe "should timeout if lock is in" do
+      def lock_failure_verify
+        begin
+          @team.reorder_lock.lock {}
+        rescue => error
+        end
+        error.should.not.be.nil
+        error.should.be.kind_of(Redis::Lock::LockTimeout)
+      end
+        
+      it "old DB" do
+        Redis.current.set(@team.reorder_lock.key, 3)
+        lock_failure_verify
+      end
+
+      it "new DB" do
+        Redis.new.set(@team.reorder_lock.key, 3)  
+        lock_failure_verify
+      end
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -71,6 +71,18 @@ REDIS_HANDLE = Redis.new(:host => REDIS_HOST, :port => REDIS_PORT)
 #$redis = REDIS_HANDLE
 Redis.current = REDIS_HANDLE
 
+# Monkey patching Redis to hold the migrating to DB called next
+class Redis
+  def self.next
+    raise "next Redis server connection needs to be explicitly set" unless @next
+    @next # ||= Redis.new
+  end
+
+  def self.next=(redis)
+    @next = redis
+  end
+end
+
 # Grab another global handle for Next DB
 require 'redis/objects'
 Redis.next = Redis.new(:host => REDIS_HOST, :port => REDIS_PORT, :db => 12)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,8 @@ if $0 =~ /\brspec$/
   raise "\n===\nThese tests are in bacon, not rspec.  Try: bacon #{ARGV * ' '}\n===\n"
 end
 
+require 'byebug'
+
 REDIS_CLASS_NAMES = [:Counter, :HashKey, :List, :Lock, :Set, :SortedSet, :Value]
 
 UNIONSTORE_KEY = 'test:unionstore'
@@ -63,10 +65,6 @@ def raises_exception(&block)
   end
   e.should.be.is_a?(StandardError)
 end
-
-#
-# TODO: Add another server
-#
 
 # Grab a global handle
 REDIS_HANDLE = Redis.new(:host => REDIS_HOST, :port => REDIS_PORT)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -64,10 +64,18 @@ def raises_exception(&block)
   e.should.be.is_a?(StandardError)
 end
 
+#
+# TODO: Add another server
+#
+
 # Grab a global handle
 REDIS_HANDLE = Redis.new(:host => REDIS_HOST, :port => REDIS_PORT)
 #$redis = REDIS_HANDLE
 Redis.current = REDIS_HANDLE
+
+# Grab another global handle for Next DB
+require 'redis/objects'
+Redis.next = Redis.new(:host => REDIS_HOST, :port => REDIS_PORT, :db => 12)
 
 SORT_ORDER = {:order => 'desc alpha'}
 SORT_LIMIT = {:limit => [2, 2]}


### PR DESCRIPTION
Hack up a temporary gem patch that supports the migration of locks from the existing Redis instance to an AWS based Redis HA instance:

- Stores a secondary (next) Redis connection in the Redis class
- Checks both DBs (current and next) for locks
- Creates new locks only in the next DB
- Updates the expiration if needed in both DBs
-  Deletes locks in both the old and new

If this is run for more than 10-20 minutes then all the locks should only be in the new Redis instance. Once we're sure all the locks are over we can deploy again by setting the Redis connection for redis-objects explicitly to the new DB.
